### PR TITLE
 removing references to cd4pe

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,13 +1,4 @@
 mod 'puppetlabs-stdlib', '6.1.0'
-mod ‘puppetlabs-cd4pe’, :latest
-# Requirements for cd4pe
-mod ‘puppetlabs-concat’, ‘4.2.1’
-mod ‘puppetlabs-hocon’, ‘1.0.1’
-mod ‘puppetlabs-puppet_authorization’, ‘0.4.0’
-mod ‘puppetlabs-stdlib’, ‘4.25.1’
-mod ‘puppetlabs-docker’, ‘3.2.0’
-mod ‘puppetlabs-apt’, ‘6.2.1’
-mod ‘puppetlabs-translate’, ‘1.1.0’
 mod 'buildtools',
   :git => 'https://github.com/faintdream/buildtools.git'
 mod 'apache',


### PR DESCRIPTION
 removing references to cd4pe, they are on the production branch by mistake.
